### PR TITLE
changed default action to open in the browser, not in hyperterm window

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Extension for [HyperTerm](https://hyperterm.org) that automatically links URLs.
 in `~/.hyperterm.js`.
 
 - focus on the HyperTerm window and `Ctrl + C` to abort opening url.
-- hold `Command` key and click a link to open it in your default browser.
+- click a link to open it in your default browser.
+- hold `Command` or `Alt`(On PC keyboard) key and click a link to open it in hyperterm window.
 
 ## Customizing styles
 

--- a/index.js
+++ b/index.js
@@ -154,15 +154,15 @@ exports.decorateTerm = function (Term, { React }) {
 
       e.preventDefault();
 
-      if (e.metaKey) {
-        // open in user's default browser when holding command key
-        shell.openExternal(e.target.href);
-      } else {
+      if (e.metaKey || e.altKey) {  // metaKey has other uses on Ubuntu which conflict with the action, so altKey is an alternative
         store.dispatch({
           type: 'SESSION_URL_SET',
           uid: this.props.uid,
           url: e.target.href
         });
+      } else {
+        // open in user's default browser by default
+        shell.openExternal(e.target.href);
       }
     }
 


### PR DESCRIPTION
fixes a problem on Ubuntu where `metaKey` is used for OS task switcher-so trying to click a link is interrupted by an OS action.