### PR TITLE
Adding custom click actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,33 @@ termCSS: `
 
 ## Configuration
 
-### Setting for open a link in default browser
+### Change link target
+`defaultBrowser` (`boolean`)
+Sets the location to open a clicked link. Holding the meta key while clicking will use the alternate target.
 
-Open in default browser when click a link.
-If holding Meta(Command) key then a link open in the Hyper.
+- true - <default> open links in the default browser
+- false - opens link in the current Hyper pane
 
-Default is `true`.
+### Change click action
+`clickAction` (`string`)
+Changes the action performed when clicking on a link
+If set, holding the meta key while clicking will open the link based on the defaultBrowser value.
 
-### e.g.) Add below config to the `.hyper`.
+- 'open' - <default> opens the link
+- 'copy' - pastes the link to your clipboard
+- 'ignore' - ignore non-Meta clicks on links
 
 ```js
-config: {
-  hyperlinks: {
-    defaultBrowser: false
+module.exports = {
+  ...
+    config: {
+    ...
+    hyperlinks: {
+    	clickAction: 'ignore',
+      defaultBrowser: false
+    }
+    ...
   }
+  ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module.exports = {
     config: {
     ...
     hyperlinks: {
-    	clickAction: 'ignore',
+      clickAction: 'ignore',
       defaultBrowser: false
     }
     ...

--- a/index.js
+++ b/index.js
@@ -5,6 +5,10 @@ const urlRegex = require('./url-regex');
 
 const emailRe = emailRegex({ exact: true });
 
+const DEFAULT_CONFIG = {
+  defaultBrowser: false
+};
+
 exports.getTermProps = function (uid, parentProps, props) {
   return Object.assign(props, { uid });
 };
@@ -15,6 +19,7 @@ exports.decorateTerm = function (Term, { React }) {
       super(props, context);
 
       this.onTerminal = this.onTerminal.bind(this);
+      this.config = null
       this.term = null
       this.id = 0;
     }
@@ -24,6 +29,7 @@ exports.decorateTerm = function (Term, { React }) {
         this.props.onTerminal(term);
       }
 
+      this.config = Object.assign({}, DEFAULT_CONFIG, window.config.getConfig().hyperlinks);
       this.term = term;
       const { screen_, onTerminalReady } = term;
 
@@ -154,19 +160,11 @@ exports.decorateTerm = function (Term, { React }) {
 
       e.preventDefault();
 
-      const defaultBrowserConfig = (function(config){
-        if (
-          config.hasOwnProperty('hyperlinks') &&
-          typeof config.hyperlinks.defaultBrowser == 'boolean'
-        ){
-          return config.hyperlinks.defaultBrowser;
-        }
-        return true;
-      })(window.config.getConfig());
+      const {defaultBrowser} = this.config;
 
       const openExternal =
-        (defaultBrowserConfig && !e.metaKey) ||
-        (!defaultBrowserConfig && e.metaKey);
+        (defaultBrowser && !e.metaKey) ||
+        (!defaultBrowser && e.metaKey);
 
       if (openExternal) {
         // open in user's default browser when holding command key


### PR DESCRIPTION
There's been confusion around links opening in Hyper or in the browser. While the default is now set to open links in the default browser I wanted to suggest some additional functions in this PR.

This new config would give two new options for clicking links: 
- Ignore the click - useful for iterm users used to only being able to Meta-click
- copy the url

Using the meta key would just open the link using the value for `defaultBrowser`

The `open` option would retain the same functionality as today. 