### PR TITLE
Fix enclosed URLs including closing brackets

### DIFF
--- a/url-regex.js
+++ b/url-regex.js
@@ -9,7 +9,7 @@ module.exports = function () {
   const domain = '(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*';
   const tld = '(?:\\.(?:[a-z\\u00a1-\\uffff]{2,}))';
   const port = '(?::\\d{2,5})?';
-  const path = '(?:[/?#][^\\s"\']*)?';
+  const path = '(?:[/?#][^\\s"\'{}|\\\\^`]*)?';
   const regex = [
     '(?:' + protocol + '|www\\.)' + auth, '(?:localhost|' + ip + '|' + host + domain + tld + ')',
     port, path

--- a/url-regex.js
+++ b/url-regex.js
@@ -15,5 +15,12 @@ module.exports = function () {
     port, path
   ].join('');
 
-  return new RegExp(regex, 'ig');
+  const match = [['<', '>'], ['[', ']'], ['(', ')']]
+    .map(function(bracket) {
+      return `(?<=\\${bracket[0]})${regex}(?=\\${bracket[1]})`;
+    })
+    .concat(regex)
+    .join('|');
+
+  return new RegExp(match, 'ig');
 };


### PR DESCRIPTION
This fixes #19 as well as URLs enclosed in `{` `}`.