### PR TITLE
Fix alignment of config prop to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If set, holding the meta key while clicking will open the link based on the defa
 ```js
 module.exports = {
   ...
-    config: {
+  config: {
     ...
     hyperlinks: {
       clickAction: 'ignore',


### PR DESCRIPTION
This removes some extra spaces before the `config` property in the example config to avoid confusion. As it is now, the `config` object looks as though it should be a sibling to the `hyperlinks` object.